### PR TITLE
fixing erroring code

### DIFF
--- a/ProgramSynthesis/ProseSample/Program.cs
+++ b/ProgramSynthesis/ProseSample/Program.cs
@@ -41,10 +41,10 @@ namespace ProseSample
             Learn(grammar, spec,
                   new Substrings.RankingScore(grammar), new Substrings.WitnessFunctions(grammar));
 
-            TestTransformation.TextBenchmark(grammar, "emails");
+            TextBenchmark(grammar, "emails");
         }
 
-        private static void TestTransformation.TextBenchmark(Grammar grammar, string benchmark, int exampleCount = 2)
+        private static void TextBenchmark(Grammar grammar, string benchmark, int exampleCount = 2)
         {
             string[] lines = File.ReadAllLines($"benchmarks/{benchmark}.tsv");
             Tuple<string, string>[] data = lines.Select(l =>


### PR DESCRIPTION
When I opened up this project and ran it, I got the following error:
```
/Users/elenaglassman/Gitrepos/glassman-prose/ProgramSynthesis/ProseSample/Program.cs(29,29): Error CS0246: The type or namespace name `TestTransformation' could not be found. Are you missing an assembly reference? (CS0246) (ProseSample)
```
I was able to remove this error by dropping `TestTransformation` from `TestTransformation.TextBenchmark` in both places it occurred.