### PR TITLE
Remove Text Splitting Demo link.

### DIFF
--- a/_includes/menu.liquid.html
+++ b/_includes/menu.liquid.html
@@ -7,8 +7,7 @@
     {% include menu-item.liquid.html url="/faq" %}
 
     {% include menu-item.liquid.html title="Demos" divided=true disabled=true %}
-    {% include menu-item.liquid.html url="/playground" title="Playground" %}
-    {% include menu-item.liquid.html url="/splitdemo" title="Text Splitting" %}
+    {% include menu-item.liquid.html url="/playground" title="Playground" %}    
 
     {% include menu-item.liquid.html title="Documentation" divided=true disabled=true %}
 


### PR DESCRIPTION
Temporarily remove Text Splitting demo link until demo is brought back to functional state.