### PR TITLE
Cloning using a .git extension can cause issues on windows

### DIFF
--- a/DslAuthoringTutorial/Readme.md
+++ b/DslAuthoringTutorial/Readme.md
@@ -15,7 +15,7 @@ If you get stuck at any of the steps in this section, please send an email to Gu
 2. Clone this repository: 
 
 ```
-git clone https://github.com/Microsoft/prose.git
+git clone https://github.com/Microsoft/prose
 cd prose\DslAuthoringTutorial\part1a
 ```
 


### PR DESCRIPTION
Some installations of git on windows prefer cloning from github without the .git extension. We should consider changing so that the instructions leave it off.