### PR TITLE
Fix TOC and multiple H1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ kramdown:
   input: GFM
   hard_wrap: false
   math_engine: mathjax
-  toc_levels: 1..1
+  toc_levels: 2..2
   syntax_highlighter: rouge
   extensions: ['options']
 

--- a/documentation/extraction-json/intro.md
+++ b/documentation/extraction-json/intro.md
@@ -2,6 +2,7 @@
 date: 2017-02-02
 title: "Json Extraction"
 ---
+{% include toc.liquid.md %}
 
 **Extraction.Json** automatically extracts tabular data from Json files. It supports extracting [Newline Delimited Json](http://ndjson.org/) and truncated Json.
 

--- a/documentation/extraction-json/usage.md
+++ b/documentation/extraction-json/usage.md
@@ -16,7 +16,7 @@ and `Microsoft.ProgramSynthesis.Extraction.Json.Semantics.dll`.
 
 The [Sample Project](https://github.com/Microsoft/prose/tree/master/Extraction.Json) illustrates our API usage.
 
-# Basic Usage
+## Basic Usage
 
 By default, **Extraction.Json** learns a *join* program in which inner arrays are joined with other fields. 
 As a result, an outer object in the input Json can be flattened into several rows in the output table.
@@ -42,7 +42,7 @@ Program noJoinProgram = noJoinSession.Learn();
 The [Introduction page]({{ site.baseurl }}/documentation/extraction-json/intro) has more discussion on this topic.
 
 
-# Serializing/Deserializing a Program
+## Serializing/Deserializing a Program
 
 The `Extraction.Json.Program.Serialize()` method serializes the learned program to a string.
 The `Extraction.Json.Loader.Instance.Load()` method deserializes the program text to a program.
@@ -54,12 +54,12 @@ string progText = program.Serialize();
 Program loadProg = Loader.Instance.Load(progText);
 ```
 
-# Executing a Program
+## Executing a Program
 
 Given an input Json, a program can generate a hierarchical tree or a flattened table.
 If the program is a join program, the table is flattened either using *outer join* (default) or *inner join* semantics.
 
-## Generating a Tree
+### Generating a Tree
 
 Use this method to obtain a hierarchical tree of the input document.
 
@@ -68,7 +68,7 @@ Use this method to obtain a hierarchical tree of the input document.
 ITreeOutput<JsonRegion> tree = program.Run(jsonText);
 ```
 
-## Generating a Table
+### Generating a Table
 
 Supply the desired join semantics to the `RunTable()` method as follows:
 

--- a/documentation/extraction-text/intro.md
+++ b/documentation/extraction-text/intro.md
@@ -15,7 +15,7 @@ The [Usage]({{ site.baseurl }}/documentation/extraction-text/usage) page and the
 **Read more:** ["FlashExtract: A Framework for Data Extraction by Examples"](https://research.microsoft.com/en-us/um/people/sumitg/pubs/pldi14-flashextract.pdf)
 
 
-# Substring Extraction
+## Substring Extraction
 
 From input/output example(s) in the form of `<input string, substring of input string>`, **Extraction.Text.Region** learns a program to extract a substring from an input string. The program can be run on new input strings to obtain new output substrings.
 
@@ -32,7 +32,7 @@ For instance, given this example:
 | Leonard `Robledo` 75 | `Robledo`   |
 
 
-# Sequence Extraction
+## Sequence Extraction
 
 From input/output example(s) in the form of `<input string, subsequence of the intended sequence>`, **Extraction.Text.Sequence** learns a program to extract a *complete* sequence of substrings from an input string. The program can be run on the same training input string to obtain the complete output sequence, or on new input strings to obtain new output sequences.
 
@@ -49,11 +49,11 @@ For instance, given this example that contains a subsequence of the intended seq
 | United States<br/> &nbsp;`Carrie` Dodson 100<br/> &nbsp;`Leonard` Robledo 75<br/> &nbsp;`Margaret` Cook 320<br/>Canada<br/> &nbsp;`Concetta` Beck 350<br/> &nbsp;`Nicholas` Sayers 90<br/> &nbsp;`Francis` Terrill 2430<br/>Great Britain<br/> &nbsp;`Nettie` Pope 50<br/> &nbsp;`Mack` Beeson 1070 | `Carrie`<br/> `Leonard`<br/> `Margaret`<br/>`Concetta` <br/>`Nicholas` <br/>`Francis` <br/>`Nettie` <br/>`Mack` |
 
 
-# Applications
+## Applications
 
 Clients may use these two APIs directly, or combine them to extract nested/hierarchical data (*i.e*, tree) from documents. Below are several real usages of **Extraction.Text**.
 
-## Operations Management Suite (OMS)
+### Operations Management Suite (OMS)
 
 The [**Custom Fields**](https://docs.microsoft.com/en-us/azure/log-analytics/log-analytics-custom-fields) feature in OMS allows users to create a new *custom* field based on an existing field in the log. **Custom Fields** uses the **Extraction.Text.Region** API because each cell in the new field is a substring of a cell in the existing field.
 
@@ -81,7 +81,7 @@ The [**Custom Log**](https://docs.microsoft.com/en-us/azure/log-analytics/log-an
 </a>
 
 
-## PowerShell ConvertFrom-String
+### PowerShell ConvertFrom-String
 
 [**ConvertFrom-String**](https://msdn.microsoft.com/en-us/powershell/reference/5.0/microsoft.powershell.utility/convertfrom-string) allows users to extract hierarchical data from a document from an example template, which is a sample of the complete document.
 

--- a/documentation/extraction-text/usage.md
+++ b/documentation/extraction-text/usage.md
@@ -13,7 +13,7 @@ These program classes have the `Serialize()` methods to serialize the program. T
 
 The [Sample Project](https://github.com/Microsoft/prose/tree/master/Extraction.Text) illustrates our API usage.
 
-# StringRegion
+## StringRegion
 
 A substring in Extraction.Text is called `StringRegion`.
 A `StringRegion` is a triple `(S, Start, End)`, where `S` is the input string, `Start` and `End` are the starting/ending positions within `S`.
@@ -53,9 +53,9 @@ StringRegion name = record.Slice(0u, 13u); // "Carrie Dodson""
 StringRegion number = record.Slice(14u, 17u); // "100"
 ```
 
-# Extracting a StringRegion
+## Extracting a StringRegion
 
-## Positive Example
+### Positive Example
 
 An `RegionExample` is a pair of an input`StringRegion` and its corresponding output `StringRegion`.
 
@@ -81,7 +81,7 @@ var example = new RegionExample(number /*100*/, name /*Carrie Dodson*/);
 
 Most applications use only the *referencing-parent* example.
 
-## Negative Example
+### Negative Example
 
 A `RegionNegativeExample` defines a subregion in which the output of the learned program should not *overlap* with.
 
@@ -91,7 +91,7 @@ For instance, the following negative example dictates that all learned programs 
 var example = new RegionNegativeExample(record /*Carrie Dodson 100*/ , name /*Carrie Dodson*/);
 ```
 
-## Basic Usage
+### Basic Usage
 
 **Extraction.Text** may take *one or more* examples to learn a region program. It accepts multiple examples that come from different regions in a file, or from different files.
 
@@ -114,7 +114,7 @@ session.Constraints.Add(
 Program topRankedProg = session.Learn();
 ```
 
-## Running RegionProgram
+### Running RegionProgram
 
 Executing the `Run(StringRegion)` method on the input string returns the extraction output.
 
@@ -140,7 +140,7 @@ This is the intended behavior of this program.
 
 Parent referencing scenario is not affected because Extraction.Text searches for the match *within* the parent.
 
-## Learning With Negative Examples
+### Learning With Negative Examples
 We specify negative examples to rule out programs whose outputs overlap with at least one of the negative examples.
 
 The below example illustrates the usage of negative examples.
@@ -166,7 +166,7 @@ foreach (StringRegion record in records)
 }
 ```
 
-## Learning With Additional References
+### Learning With Additional References
 
 We may provide additional references (which may come from the same file or different files) to the learning session.
 **Extraction.Text** observes the behavior of the learnt programs on these additional references, and uses this observation to better rank programs.
@@ -196,7 +196,7 @@ foreach (StringRegion record in records)
 }
 ```
 
-## Learning With Regular Expressions
+### Learning With Regular Expressions
 
 Users also have an option to provide 3 regular expressions for the extracted region: the lookbehind regex, the matching regex, and the lookahead regex.
 All 3 regular expressions are optional.
@@ -226,7 +226,7 @@ foreach (StringRegion record in records)
 ```
 
 
-# Extracting a Sequence of StringRegions
+## Extracting a Sequence of StringRegions
 
 Learning a program to extract a sequence of `StringRegion` is similar to learning a program to extract a `StringRegion`.
 
@@ -238,7 +238,7 @@ Learning a program to extract a sequence of `StringRegion` is similar to learnin
 > Extraction.Text assumes that all the text prior to the last example that are not selected are negative examples.
 > For instance, in extracting {"A", "C"} from "A B C", Extraction.Text assumes that " B " is a negative example.
 
-## Positive Example
+### Positive Example
 
 An `SequenceExample` is a pair of an input `StringRegion` and its corresponding *subsequence* of the indented output sequence.
 
@@ -258,7 +258,7 @@ var sequenceExample = new SequenceExample(
 
 Similar to `Example` in region learning, a `SequenceExample` can also be one of the three referencing kinds, in which *referencing-parent* is the most popular (it is also demonstrated above).
 
-## Negative Example
+### Negative Example
 
 A `SequenceNegativeExample` defines a subregion in which the output of the learned program should not *overlap* with.
 
@@ -268,7 +268,7 @@ For instance, the following negative example dictates that the output of all lea
 var example = new SequenceNegativeExample(input , input.Slice(0, 13) /*United States*/);
 ```
 
-## Basic Usage
+### Basic Usage
 
 The examples (if any) in each referencing region have to be continuous.
 However, we do not need to provide all examples in previous regions before providing examples in the current region.
@@ -306,11 +306,11 @@ The other APIs for learning a sequence program are similar to their region learn
 
 
 
-# Learning multiple programs
+## Learning multiple programs
 
 There are usually a large number of programs consistent with any given set of examples. **Extraction.Text** uses a ranking scheme to return the most likely program for the examples, but in some cases this may not be the desired program.
 
-## Learn Top k Programs
+### Learn Top k Programs
 
 `LearnTopK` returns the top `k` ranked programs. If there are fewer than `k` programs, this method returns all programs. If there are tied programs at `k`, it includes all tied programs.
 
@@ -338,7 +338,7 @@ foreach (RegionProgram prog in topKPrograms)
 }
 ```
 
-## Learn All Programs
+### Learn All Programs
 
 `LearnAll` returns a set of all programs consistent with the examples.
 
@@ -369,7 +369,7 @@ foreach (ProgramNode prog in topKPrograms)
 ```
 
 
-# Serializing/Deserializing a Program
+## Serializing/Deserializing a Program
 
 The  `Serialize()` methods of `RegionProgram` and `SequenceProgram` serialize the learned `RegionProgram` and `SequenceProgram` to a string.
 The `Load()` methods of `RegionLoader` and `SequenceLoader` deserialize the program text to a `RegionProgram` and `SequenceProgram`.

--- a/documentation/matching-text/usage.md
+++ b/documentation/matching-text/usage.md
@@ -3,8 +3,6 @@ date: 2018-05-23
 title: "Matching Text - Usage"
 ---
 
-{% include toc.liquid.md %}
-
 The `Matching.Text` API is accessed through the
 [`Matching.Text.Session`](https://prose-docs.azurewebsites.net/html/T_Microsoft_ProgramSynthesis_Matching_Text_Session.htm) class.
 The input strings are added using [`Session.Constraints.Add()`](https://prose-docs.azurewebsites.net/html/M_Microsoft_ProgramSynthesis_Wrangling_Session_Session_3_AddConstraints.htm).

--- a/documentation/matching-text/usage.md
+++ b/documentation/matching-text/usage.md
@@ -16,8 +16,7 @@ Each `PatternInfo` object either has:
 
 The other fields indicate the frequency of the pattern (`MatchingFraction`), a description in a PROSE specific format (`Description`), and a few examples of the input strings matched by the pattern (`Examples`).
 
-Basic usage
-===========
+## Basic usage
 
 ```csharp
 using Microsoft.ProgramSynthesis.Matching.Text;

--- a/documentation/prose/backpropagation.md
+++ b/documentation/prose/backpropagation.md
@@ -1,18 +1,19 @@
 ---
 title: Backpropagation
 ---
+{% include toc.liquid.md %}
 
 Deductive strategy (i.e., backpropagation) is the main synthesis algorithm used by the PROSE SDK.
 It relies on external annotations, provided by the DSL designer for the language operators -- [witness functions](#witness-functions).
 Our [tutorial]({{ site.baseurl }}/documentation/prose/tutorial) and samples show many use cases for specific witness functions.
 
-# Witness Functions
+## Witness Functions
 A witness function is a domain-specific deductive procedure for a parameter $k$ of an operator $F$, that, given an outer spec $\phi$ on $F$, answer a question: "What should a program used as this parameter satisfy in order for the entire $F$ expression to satisfy $\phi$?"
 In other words, witness functions *backpropagate* specifications from expressions to their subexpressions.
 
 There are two kinds of witness functions: non-conditional and conditional.
 
-## Non-conditional
+### Non-conditional
 Non-conditional witness functions have the following signature:
 
 ``` csharp
@@ -31,7 +32,7 @@ If `outerSpec` is inconsistent (no program can possibly satisfy it), witness fun
 `null` in PROSE is a placeholder for an "always false" spec.
 (An "always true" spec is called `TopSpec`).
 
-## Conditional
+### Conditional
 
 Conditional witness functions depend not only on an outer spec on their operator, but also possibly on some other parameters of that operator.
 They have the following signature:
@@ -46,7 +47,7 @@ Typically they will be `ExampleSpec`s: deductive reasoning is easiest when you k
 
 You can use `DependsOnSymbols = new[] { prereqName1, prereqName2, ... }` in the attribute, referring to parameter names instead of their indices (if they are unambiguous).
 
-## ID Annotations
+### ID Annotations
 If a target grammar rule does not have a name (for instance, it is a `let` rule or a conversion rule `A := B`), you can use an `@id` annotation in the grammar file to give it one, and then use this name as a reference in `[WitnessFunction]` attributes.
 
 ```
@@ -62,7 +63,7 @@ Spec Witness(LetRule rule, Spec outerSpec);
 In case of a `let` rule, it has two parameters: its "binding" expression (the part on the right-hand side of an equal sign) and its "body" expression (the part after **`in`**).
 PROSE provides an automatic witness function for the body parameter, so you only to write one for the binding parameter (whose index in the containing `let` rule is $0$).
 
-# Rule Learners
+## Rule Learners
 *Rule learners* are designed for use cases when you cannot express you deductive logic in terms of witness functions on individual parameters.
 They are mini-strategies: search algorithms for one grammar rule.
 

--- a/documentation/prose/concepts.md
+++ b/documentation/prose/concepts.md
@@ -1,12 +1,13 @@
 ---
 title: Standard concepts
 ---
+{% include toc.liquid.md %}
 
 ***Standard concepts*** are built-in PROSE operators.
 They have predefined semantics and, most of the time, witness functions for [backpropagation]({{site.baseurl}}/documenation/prose/backpropagation).
 Thus, you can use standard concepts arbitrarily in your own DSLs without reimplementing them or designing your own synthesis procedures for them.
 
-# Concept rules
+## Concept rules
 
 The grammar syntax for a simple *concept rule* looks as follows:
 
@@ -28,7 +29,7 @@ The parameter symbols `E1`, $...$, `Ek` are passed directly to the standard conc
 >
 > The two `r` parameters denote the regexes to the left and to the right of a given position boundary. They are united into a tuple with a standard concept `Pair`.
 
-## Lambda functions
+### Lambda functions
 
 More complex concept rules may include a *lambda function* on their right-hand side.
 For instance, a list-processing operator `Filter` takes as input a predicate of type `Func<T, bool>` and a sequence of type `IEnumerable<T>`, and returns the filtered subsequence of elements that satisfy the predicate.
@@ -52,7 +53,7 @@ Here the *custom operator* `Selected(f, v)` is implemented as a *concept rule* `
 The first parameter of `Filter` is a lambda `\x: string => f`, and the second one is `v`.
 Notice that *you can either use a formal parameter directly in a concept, or pass it down into a lambda body*.
 
-# List of concepts
+## List of concepts
 
 Concept                                           | Semantics                      | Specs handled by PROSE    | Witness functions needed?
 -----------|----------------------------------|--------------------------------|---------------------------|--------------------------

--- a/documentation/prose/interactivity.md
+++ b/documentation/prose/interactivity.md
@@ -42,7 +42,7 @@ var session = new Session();
 ```
 
 
-# Inputs
+## Inputs
 
 The collection of all known inputs the program is expected to be run on
 should be provided using
@@ -68,7 +68,7 @@ session.Inputs.Add(new InputRow("Greta", "Hermansson"),
 ```
 
 
-# Constraints
+## Constraints
 
 Constraints are any information that describe the program to be synthesized.
 The most common kind of constraint is an [example](https://prose-docs.azurewebsites.net/html/T_Microsoft_ProgramSynthesis_Wrangling_Constraints_Example_2.htm),
@@ -95,7 +95,7 @@ session.Constraints.Add(new Example(new InputRow("Greta", "Hermansson"), "Herman
 ```
 
 
-# Synthesizing programs
+## Synthesizing programs
 
 Once a `Session` has some inputs and constraints, a program can be synthesized.
 Programs are generated using the various `.Learn*()` methods, which use the
@@ -116,7 +116,7 @@ var program = session.Learn();
 ```
 
 
-# Explanations
+## Explanations
 
 In order to decide if the synthesized program is satisfactory, the user has
 to comprehend what has been learned. As we assume that, in general, the
@@ -127,7 +127,7 @@ be easy for a computer to synthesize programs in as opposed to being
 easy for a human to read.
 
 
-## Running the program
+### Running the program
 
 The most straightforward way to explain the program is to run it.
 To run a `Program`, use its [`Run()`](https://prose-docs.azurewebsites.net/html/M_Microsoft_ProgramSynthesis_Program_2_Run.htm) method:
@@ -146,7 +146,7 @@ foreach(var input in session.Inputs)
 | Etelka | bala       | bala, E.       |
 
 
-## DSL-specific
+### DSL-specific
 
 Other explanations might be DSL-specific. For instance, `Transformation.Text`
 offers a feature called "[output provenance](https://prose-docs.azurewebsites.net/html/M_Microsoft_ProgramSynthesis_Transformation_Text_Program_ComputeOutputProvenance.htm)"
@@ -174,7 +174,7 @@ input a specific part of the output should come from, although the current
 implementation of `Transformation.Text` does not support such a constraint.
 
 
-# Significant Inputs
+## Significant Inputs
 
 While explanations help the user understand how the program works on inputs
 they are looking at, if the input set is large, it is likely some problems
@@ -208,7 +208,7 @@ to define the program to synthesize (modulo the inputs provided),
 which should give the user confidence that the synthesized program is correct.
 
 
-# Conclusion
+## Conclusion
 
 PROSE&apos;s `Session` API provides a mechanism for supporting an
 interactive synthesis task. After loading in the data to work with,

--- a/documentation/prose/syntax.md
+++ b/documentation/prose/syntax.md
@@ -9,7 +9,7 @@ This document describes the syntax of PROSE v1 DSL grammars.
 
 > Hereafter in the general syntax descriptions, angle brackets `<>` denote a placeholder to be filled with a concrete value, and curly braces `{}` with an `opt` subscript denote an optional component (unless specified otherwise).
 
-# Basic structure
+## Basic structure
 
 The basic structure of a `*.grammar` file is as follows:
 
@@ -29,9 +29,9 @@ language <Name>;
 It first specifies some metadata about the DSL, and then describes it as a grammar. A PROSE language is represented as a [context-free grammar](https://en.wikipedia.org/wiki/Context-free_grammar) – *i.e.,* as a set of *rules*, where each *symbol* on the left-hand side is bound to a set of possible expansions of this symbol on the right-hand side.
 
 
-# Usings
+## Usings
 
-## Namespace usings
+### Namespace usings
 
 These statements are identical to the corresponding C# forms. They import a namespace into the current scope.
 
@@ -40,7 +40,7 @@ using System.Text.RegularExpressions;
 ```
 {: .language-bnf}
 
-## Semantics usings
+### Semantics usings
 
 These statements specify *semantics holders* – static classes that contain implementations of the grammar's operators. There may be more than one semantics holder, as long as their members do not conflict with each other.
 
@@ -49,7 +49,7 @@ using semantics TestLanguage.Semantics.Holder;
 ```
 {: .language-bnf}
 
-## Learner usings
+### Learner usings
 
 These statements specify *learning logic holders* – non-static classes that inherit `DomainLearningLogic` and contain domain-specific helper learning logic such as [witness functions]({{site.baseurl}}/documentation/prose/backpropagation/#witness-functions) and value generators. There may be more than one learning logic holder.
 
@@ -58,11 +58,11 @@ using learners TestLanguage.Learning.LogicHolder;
 ```
 {: .language-bnf}
 
-# Language name
+## Language name
 
 May be any valid C# *full type identifier* – that is, a dot-separated string where each element is a valid C# identifier.
 
-# Features
+## Features
 
 A [feature]({{site.baseurl}}/documentation/prose/tutorial/#features) is a computed property on an AST in the language. Each such property has a name, type, and associated *feature calculator* functions that compute the value of this property on each given AST. A feature may be declared as *complete*, which requires it to be defined on every possible AST kind in the language. By default, a feature is not complete.
 
@@ -92,7 +92,7 @@ feature HashSet<int> UsedConstants = TestLanguage.UsedConstantsCalculator;
 ```
 {: .language-bnf}
 
-# Terminal rules
+## Terminal rules
 
 Each *terminal symbol* of the grammar is associated with its own unique *terminal rule*. Terminal rules specify the leaf symbols that will be replaced with literal constants or variables in the AST. For example:
 
@@ -106,13 +106,13 @@ Each *terminal symbol* of the grammar is associated with its own unique *termina
 ```
 {: .language-bnf}
 
-## Annotations
+### Annotations
 
-#### `@input`
+##### `@input`
 
 Denotes the input variable passed to the DSL programs. A DSL program may depend only on a single input variable, although of an arbitrary type.
 
-#### `@values`
+##### `@values`
 
 A user can specify the list of possible values that a literal symbol can be set to. This is done with a **@values[**$G$**]** annotation, where $G$ is a **value generator** – a reference to a user-defined static field, property, or method. The compiler will search for $G$ in the provided learning logic holders, and will report an error if it does not find a type-compatible member.
 
@@ -149,7 +149,7 @@ namespace TestLanguage
 }
 ```
 
-# Nonterminal rules
+## Nonterminal rules
 
 A *nonterminal rule* describes a possible [production](https://en.wikipedia.org/wiki/Production_(computer_science)) in a context-free grammar of the DSL. In contrast to conventional programming languages, the productions of PROSE grammars describe not the surface syntax of DSL programs, but their direct semantics as ASTs. In other words, where a conventional context-free grammar would specify something like
 
@@ -166,7 +166,7 @@ expression := Plus(atom, atom) | Minus(atom, atom) ;
 
 This snippet contains two nonterminal rules `expression := Plus(atom, atom)` and `expression := Minus(atom, atom)`. The functions `Plus` and `Minus` are *operators* in the grammar – domain-specific functions that may be included as steps of your  DSL programs. Thusly, PROSE DSLs do not have a syntax – they directly describe a grammar of possible domain-specific program actions.
 
-## Structure
+### Structure
 
 Every nonterminal rule has a *head* and a *body*. Its head is a typed *nonterminal symbol* on the left-hand side of the production. Its body is a sequence of free symbols on the right-hand side, which may be nonterminal or terminal (i.e. variables or constants). There exist multiple different kinds of nonterminal rules, which differ in their semantics as well as in the roles of the symbols in their bodies.
 
@@ -177,32 +177,32 @@ Every nonterminal rule has a *head* and a *body*. Its head is a typed *nontermin
 ```
 {: .language-bnf}
 
-### Annotations
+#### Annotations
 
-#### `@start`
+##### `@start`
 
 An optional annotation that specifies the _start symbol_ of the grammar – that is, the root nonterminal symbol of all programs in this DSL.
 
-## Operator rules
+### Operator rules
 
 > Coming soon...
 
-## Conversion rules
+### Conversion rules
 
 > Coming soon...
 
-## Let bindings
+### Let bindings
 
 > Coming soon...
 
-## Standard concepts
+### Standard concepts
 
 > Coming soon...
 
-### Lambda functions
+#### Lambda functions
 
 > Coming soon...
 
-## External rules
+### External rules
 
 > Coming soon...

--- a/documentation/prose/usage.md
+++ b/documentation/prose/usage.md
@@ -5,7 +5,7 @@ title: Usage
 
 {% include toc.liquid.md %}
 
-# Terminology
+## Terminology
 
 A **domain-specific language (DSL)** is a context-free programming
 language, created for a specific purpose, which can express tasks from a
@@ -28,7 +28,7 @@ which the program is invoked. AST nodes can modify this state (add new
 variable bindings in scope) and pass it down to children nodes in
 recursive invocations of `Invoke`.
 
-# Architecture
+## Architecture
 
 The Microsoft.ProgramSynthesis package unites the core pieces of the meta-synthesizer.
 Here are the included assemblies:
@@ -62,7 +62,7 @@ A typical workflow of a DSL designer consists of the following steps:
         application. At run-time, compile your DSL definition in memory
         using `DSLCompiler.Compile` method.
 
-# Language definition
+## Language definition
 
 The main class `Grammar` represents a context-free grammar as a
 set of DSL rules and a list of references to operators’ semantics and/or
@@ -114,7 +114,7 @@ is a start symbol of the grammar (i.e., the topmost node of every AST).
 Exactly one terminal rule should be annotated as “**@input**” – this is
 the input data to the program.
 
-## Terminals
+### Terminals
 
 Terminal rules specify the leaf symbols that will be replaced with
 literal constants or variables in the AST. For example:
@@ -156,7 +156,7 @@ standard generator for some common types (such as `byte`), or
 assume that the literal can be set to any value. This can impact the
 performance of some synthesis strategies or even make them inapplicable.
 
-## Black-box operators
+### Black-box operators
 
 A **black-box** operator is an operator that does not refer to any
 standard concepts, and its invocation semantics do not modify the
@@ -244,7 +244,7 @@ their operators on anything other than the program input data, they have
 to introduce additional variables using `Let` construct and/or
 lambda functions.
 
-## Let construct
+### Let construct
 
 `Let` construct is a standard concept with the following syntax:
 
@@ -293,7 +293,7 @@ program (AST). The first symbol is a variable $x$; when executed on a
 state $\sigma'$, it will just extract the binding $x \mapsto \vartheta$
 from it, and return $\vartheta$.
 
-## Standard concepts
+### Standard concepts
 
 There exists a range of concepts that are common for many DSLs and
 implement standard functionality. In particular, many list/set
@@ -366,7 +366,7 @@ should satisfy the following contract:
     `Filter` concept specifically, the return type of this
     “function” should be assignable to `bool`.
 
-### Lambda functions
+#### Lambda functions
 
 One can capture functional semantics in an explicit
 lambda function in the grammar:
@@ -449,7 +449,7 @@ on the RHS is resolved as follows:
 Two usages of the same symbol $P$ among parameters were resolved in a
 left-to-right order.
 
-# Language usage
+## Language usage
 
 Definition and usage of custom DSLs starts with the following steps:
 
@@ -481,7 +481,7 @@ var grammar = DSLCompiler.Compile(new CompilerOptions()
     }).Value;
 ```
 
-## Partial programs
+### Partial programs
 
 In many applications there is need to manipulate **partial programs** –
 ASTs where some tree nodes are replaced with **holes**. A hole is a
@@ -501,9 +501,9 @@ children, and $H$ is the hole itself.
 A string representation of a hole of symbol $S$ is **“?S”.** The
 framework supports parsing AST strings that contain holes.
 
-# Synthesis
+## Synthesis
 
-## Specifications
+### Specifications
 
 Program synthesis in the PROSE SDK is defined as a process of
 generating a **set of programs** $\tilde{P}$ that start with a
@@ -568,7 +568,7 @@ Some of the main inductive specification kinds are described below:
         that specifies the single desired program output for each
         provided input state.
 
-## Strategies
+### Strategies
 
 The main point of program synthesis in the framework is the
 `SynthesisEngine` class. Its function is to execute different
@@ -610,7 +610,7 @@ whether this synthesis strategy supports learning for a given
 specification `spec` (in the default implementation, the result is
 `true` if and only if `spec` is an instance of `TSpec`).
 
-## Version space algebra
+### Version space algebra
 
 The return type of `Learn` in `SynthesisStrategy` is
 `Microsoft.ProgramSynthesis.VersionSpace.ProgramSet`. This is an
@@ -658,7 +658,7 @@ public abstract class ProgramSet : ILanguage
 The property `RealizedPrograms` calculates the set of programs
 stored in the version space.
 
-### Direct version space
+#### Direct version space
 Direct version space is a primitive version space
 that represents a set of programs explicitly, by storing a reference to
 `IEnumerable<ProgramSet>`. Since
@@ -670,7 +670,7 @@ the required number of consistent programs on the fly, as needed.
 Moreover, such an iterator can even be theoretically infinite, as long
 as the end-user requests only a finite number of consistent programs.
 
-### Union version space
+#### Union version space
 A union of $k$ version spaces is a version space
 that contains those and only those programs that belong to at least one
 of the given $k$ spaces. Such a version space naturally arises when we
@@ -689,7 +689,7 @@ $G(?C,\ \ ?D)$. If all the programs in $\tilde{F}$ and $\tilde{G}$ are
 consistent with $\varphi$, then $\tilde{F} \cup \tilde{G}$ is a valid
 answer to the outer learning task $\left\langle P,\varphi \right\rangle$.
 
-### Join version space
+#### Join version space
 A join version space is defined for a single
 operator `$P := F\left( E_{1},\ldots,E_{k} \right)$`. It represents a set of
 programs $\tilde{P}$ formed by a Cartesian product of parameter version

--- a/documentation/split-text/intro.md
+++ b/documentation/split-text/intro.md
@@ -2,6 +2,7 @@
 date: 2017-02-01T20:00:06-07:00
 title: "Text Splitting"
 ---
+{% include toc.liquid.md %}
 
 **Split.Text** is a system for splitting data in plain text format, where there may be multiple fields that need to be separated into different columns. The [Usage]({{ site.baseurl }}/documentation/split-text/usage) page and the [`Split.Text` sample project](https://github.com/Microsoft/prose/tree/master/Split.Text) show examples of how to use the Split.Text API. The Split.Text system supports purely predictive as well as interactive techniques to learn programs for splitting textual data. 
 

--- a/documentation/transformation-text/usage.md
+++ b/documentation/transformation-text/usage.md
@@ -16,8 +16,7 @@ In order to use `Transformation.Text`, you need assembly references to
 `Microsoft.ProgramSynthesis.Transformation.Text.Semantics.dll`.
 
 
-Basic usage
-===========
+## Basic usage
 
 ```csharp
 Session session = new Session();
@@ -38,7 +37,7 @@ without naming the columns. To get more control,
 implement `Transformation.Text`&apos;s [`IRow`](https://prose-docs.azurewebsites.net/html/T_Microsoft_ProgramSynthesis_Transformation_Text_Semantics_IRow.htm) interface.
 
 
-#### One example with multiple strings
+### One example with multiple strings
 
 ```csharp
 var session = new Session();
@@ -53,7 +52,7 @@ current version. The cast to `string` is done using `as string`
 to acknowledge that future versions of `Transformation.Text`
 may support other return types.)
 
-#### Multiple examples
+### Multiple examples
 
 `Transformation.Text` can be given multiple examples in order to generate a
 program that
@@ -92,8 +91,7 @@ string output = program.Run(new InputRow("425 311 1234")) as string; // output i
 ```
 
 
-Inputs without known outputs
-============================
+## Inputs without known outputs
 
 Most likely, when learning a program, you will have some idea of other inputs
 you intend to run the program on in the future. `Transformation.Text`
@@ -109,8 +107,7 @@ string output = program.Run("31/01/1983") as string; // output is "1983-01-31"
 ```
 
 
-Learning multiple programs
-==========================
+## Learning multiple programs
 
 There are usually a large number of programs consistent with any given set of
 examples. `Transformation.Text` has a ranking scheme which it uses to return
@@ -150,8 +147,7 @@ foreach (object output in outputs)
 }
 ```
 
-Serializing programs
-====================
+## Serializing programs
 
 Sometimes you will want to learn a program in one session and run it on other
 data in a future session or transfer learned programs between computers.
@@ -169,14 +165,12 @@ Program parsedProgram = Loader.Instance.Load(serializedProgram);
 Console.WriteLine(parsedProgram.Run(new InputRow("Etelka Bala"))); // outputs "Bala, E."
 ```
 
-API
-===
+## API
 
 See [Documentation]({{ site.baseurl }}/documentation/api) for the full API documentation.
 
 
-Learning `Transformation.Text` programs
----------------------------------------
+### Learning `Transformation.Text` programs
 
 To start, construct an empty [`Session`](https://prose-docs.azurewebsites.net/html/T_Microsoft_ProgramSynthesis_Transformation_Text_Session.htm)
 which encapsulates learning a program for a single task, often refined

--- a/faq.md
+++ b/faq.md
@@ -4,16 +4,16 @@ title: FAQ
 ---
 {% include toc.liquid.md %}
 
-# General questions
+## General questions
 
-## How do I use it?
+### How do I use it?
 
 The SDK is used through .NET APIs.
 See the [tutorial]({{ site.baseurl }}/documentation/prose/tutorial) for how to get
 started and the documentation links on the sidebar for more details.
 
 
-## How do I install it?
+### How do I install it?
 
 Install the `Microsoft.ProgramSynthesis` and (optionally) `Microsoft.ProgramSynthesis.Compiler` NuGet packages in Visual Studio.
 
@@ -25,11 +25,11 @@ npm install -g generator-prose
 yo prose
 ```
 
-## Is it cross-platform?
+### Is it cross-platform?
 Yes, PROSE SDK is supported on Windows, Linux, and macOS.
 Currently, the package is guaranteed to work on .NET 4.5+ and .NET Core.
 
-## Where can I use it?
+### Where can I use it?
 
 The SDK is released under a _non-commercial license_ for use in
 research, education, and non-commercial applications. See
@@ -37,18 +37,18 @@ research, education, and non-commercial applications. See
 for details.
 
 
-## Where can I find sample code?
+### Where can I find sample code?
 
 Our samples are located in the [PROSE GitHub repository](https://github.com/microsoft/prose).
 
-## How can I contact you if I have any questions or feedback?
+### How can I contact you if I have any questions or feedback?
 
 If you run into any bugs or issues, please [open an issue](https://github.com/microsoft/prose/issues) in our GitHub repository.
 Feel free also to [email us](mailto:prose-contact@microsoft.com).
 
-# Visual Studio Code on Linux
+## Visual Studio Code on Linux
 
-## How do I restore NuGet packages for a PROSE solution (a sample or a `yo`-generated template)?
+### How do I restore NuGet packages for a PROSE solution (a sample or a `yo`-generated template)?
 
 ``` terminal
 sudo apt install mono-complete nuget
@@ -56,14 +56,14 @@ sudo nuget update -self
 nuget restore YourSolution.sln
 ```
 
-## How do I build a solution in VS Code?
+### How do I build a solution in VS Code?
 
 Press <kbd>Ctrl+Shift+P</kbd> and [configure a task runner](https://code.visualstudio.com/docs/editor/tasks). Pick the `msbuild` task. In the generated `tasks.json`, replace `msbuild` with `xbuild`.
 
-## When I try to run xbuild on my yo-generated solution, it fails with an error about `@(AssemblyPaths -> Replace('/', '/'))`.
+### When I try to run xbuild on my yo-generated solution, it fails with an error about `@(AssemblyPaths -> Replace('/', '/'))`.
 
 As it turns out, `xbuild` does not support the entirety of the `msbuild` language. This means that you won't be able to recompile your grammar automatically on each build out of the box. We are working on fixing this. In the meantime, please regenerate your solution with `yo prose` but **answer "No" to the last question**.
 
-## How do I launch a program or debug it in VS Code?
+### How do I launch a program or debug it in VS Code?
 
 Install the [mono-debug](https://marketplace.visualstudio.com/items?itemName=ms-vscode.mono-debug) extension for VS Code and follow the instructions on its webpage.

--- a/impact.md
+++ b/impact.md
@@ -2,7 +2,7 @@
 title: Impact
 ---
 
-# Azure ML Workbench
+## Azure ML Workbench
 
 Azure ML Workbench is a cross-platform environment for *data wrangling*, *ML experimentation*, and *operationalization*. 
 Workbench builds on top of PROSE SDK, including *column derivation by example*, *splitting*, *combination*, *JSON expansion*, *autocompletion*.
@@ -13,7 +13,7 @@ More information:
 - [Derive column by example transformation](https://docs.microsoft.com/en-us/azure/machine-learning/preview/data-prep-derive-column-by-example)
 - [Bike-share tutorial: Advanced data preparation with Azure Machine Learning Workbench](https://docs.microsoft.com/en-us/azure/machine-learning/preview/tutorial-bikeshare-dataprep)
 
-# SQL Server Management Studio - Import Flat File
+## SQL Server Management Studio - Import Flat File
 
 Our predictive program synthesis technology has been released in SQL Server Management Studio,
 behind the new feature *Import Flat File Wizard*, which helps streamline the import experience for a user who wants to import `.csv` or `.txt` files without specialized domain knowledge.
@@ -24,7 +24,7 @@ This feature builds on top of the PROSE SDK, and leverages ideas from the follow
 Video describing the feature:
 - [Introducing the new Import Flat File Wizard in SSMS 17.3](https://channel9.msdn.com/Shows/Data-Exposed/Introducing-the-new-Import-Flat-File-Wizard-in-SSMS-173)
 
-# Stack OverFlow Bot
+## Stack OverFlow Bot
 
 Our _Flash Fill++_ technology is part of the *Stack Overflow Bot*.
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -3,9 +3,9 @@ title: Release Notes
 ---
 {% include toc.liquid.md %}
 
-# Release 6.10.0 -- 2018/12/17
+## Release 6.10.0 -- 2018/12/17
 
-## New Features
+### New Features
 
 - Compound.Split
     - Added support to read CSV/FW files with "junk rows"; that is, repeated headers and non-data, non-comment rows,
@@ -16,7 +16,7 @@ title: Release Notes
       on a specific data set rather than generating code for doing so.
     - Make the Python code generator available in the C# SDK.
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Compound.Split
     - Improve handling of comments and empty records.
@@ -32,14 +32,14 @@ title: Release Notes
     - Refactored the grammar to merge predicates related to the current node, parent node, and children.
 
 
-# Release 6.9.0 -- 2018/11/16
+## Release 6.9.0 -- 2018/11/16
 
-## Breaking changes
+### Breaking changes
 
 - Compound.Split
     - Hides the ReadInputLineCount constraint and instead users can specify no. of lines to read while adding inputs.
     
-## New Features
+### New Features
 
 - Transformation.Text
     - Generate readable python code for Lookup() semantics operator.
@@ -47,7 +47,7 @@ title: Release Notes
     - Parametrized the SimplePrograms constraint by program input and output type, allowing it to be used for any kind
       of program (field extraction, sequence extraction, etc).
     
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Detection.DataType 
     - Better handling of integer columns that look like categorical data, and handling of “NaN” values in string columns.
@@ -77,9 +77,9 @@ title: Release Notes
     - Fix a bug where learning on large input could lead to StackOverflow.
         
 
-# Release 6.8.1 -- 2018/10/18
+## Release 6.8.1 -- 2018/10/18
 
-## Breaking Changes
+### Breaking Changes
 
 - Compound.Split
     - `ReadInputFromReaders(TextReader reader)` and `ReadInputLineCount(int limit)` are deprecated. They are replaced by
@@ -90,7 +90,7 @@ title: Release Notes
     -   Removed the optional `JPath` parameter from the constraint `JoinSingleTopArray` – the new constraint `JoinArray`
         should be used instead.
 
-## New Features
+### New Features
 
 -   Common Framework
 	-   New learning/running exception hierarchy to raise friendlier exceptions.
@@ -110,7 +110,7 @@ title: Release Notes
     -   `Node.Value` of type `string` has been replaced by `Node.Attributes` of type `Dictionary<string, string>` to
         permit learning from distinct attributes.
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 -   Detection.DataType
 	-   Various bug fixes and enhancement.
@@ -131,9 +131,9 @@ title: Release Notes
 	-   Various bug fixes.
 
 
-# Release 6.7.0 -- 2018/09/20
+## Release 6.7.0 -- 2018/09/20
 
-## New Features
+### New Features
 
 - Common framework
     - Configurable equality for `FeatureCalculationContext`; Classes implementing `IFeature` can now force deep/shallow
@@ -150,7 +150,7 @@ title: Release Notes
     - Support added for `UseLongConstantOptimization` constraint which aggressively generates constant tokens whenever
       possible. (Note: This makes the learning incompelete.)
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Common framework
     - Optimizations and style improvements in quality of generated Python code.
@@ -172,15 +172,15 @@ title: Release Notes
     - Improved row selector inference based on ancestor nodes rather than just the boundary nodes.
 
 
-# Release 6.6.0 -- 2018/08/20
+## Release 6.6.0 -- 2018/08/20
 
-## Breaking Changes
+### Breaking Changes
 
 - Compound.Split
     - The property `FieldStartPositions` has been removed and a new `IReadOnlyList<Record<int, int?>> FieldPositions`
       property has been added in its place.
 
-## New Features
+### New Features
 
 - Common Framework
     - Support for serialization and deserialization of spec objects (used to track subtasks during synthesis).
@@ -211,7 +211,7 @@ title: Release Notes
 - Transformation.Text
     - Support for serialization and deserialization for all types referenced in the grammar.
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Common Framework
     - Bug fixes in ProgramSet.TopK(k) method to return no less than k programs. Temporarily, this slightly degrades
@@ -231,14 +231,14 @@ title: Release Notes
     - Performance improvement using incremental learning such that previously learned programs are updated with newer
       examples provided on subsequent Learn() calls.
 
-# Release 6.5.0 -- 2018/07/23
+## Release 6.5.0 -- 2018/07/23
 
-## New Features
+### New Features
 
 - Extraction.Web:
     - Now supports predictive table extraction from webpages (that is, from 0 examples).
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Common framework:
     - Added support for a common extension hook for custom entity detectors.  This hook is currently used in 
@@ -264,9 +264,9 @@ title: Release Notes
     - Readability of python translations is improved in some cases by removing unnecessary wrapping functions/classes.
     - Python translator now creates much more readable translations for programs including date time rounding.
 
-# Release 6.4.0 -- 2018/06/26
+## Release 6.4.0 -- 2018/06/26
 
-## Breaking Changes
+### Breaking Changes
 
 - Common Framework
     - When running on CoreClr, we now require runtime version 2.0.3 or newer.  Previously we had workarounds for a
@@ -286,7 +286,7 @@ title: Release Notes
         - NormalizeArrays -> JoinSingleTopArray
         - SplitTopArrayToColumns -> SplitTopArrays
 
-## New Features
+### New Features
 
 - Common Framework
     - VSA data structures now support Serialization and Deserialization
@@ -301,7 +301,7 @@ title: Release Notes
 - Extraction.Json
     - Now supports trailing commas.
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Compound.Split
     - Improved learning of header/skip.
@@ -347,16 +347,16 @@ title: Release Notes
     - Program now exposes separate methods for finding the nodes that should be changed and for performing the
       transformation instead of just doing the whole operation in a single method call.
 
-# Release 6.3.0 -- 2018/05/15
+## Release 6.3.0 -- 2018/05/15
 
-## Breaking Changes
+### Breaking Changes
 
 - Matching.Text
     - ForbidConstantTokens constraint has been removed.
 - Transformation.Tree
     - Utils.Parse has been renamed to Utils.ParseStatementIgnoreWhiteSpace
     
-## New Features
+### New Features
 
 - Compound.Split
     - Key/Value extraction now supports fixed width extraction such as where the keys and values are in a table where
@@ -365,7 +365,7 @@ title: Release Notes
 - Transformation.Text
     - Now supports pluggable Entity Detectors specified in a constraint.
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Common Framework
     - PROSE now depends on a slightly older version of Newtonsoft.Json (v9.0.1) for .Net Framework consumers.  For
@@ -389,20 +389,20 @@ title: Release Notes
       apply them to specific nodes bypassing the filter checking.
     - Performance improvements.
 
-# Release 6.2.0 -- 2018/04/25
+## Release 6.2.0 -- 2018/04/25
 
-## Breaking Changes
+### Breaking Changes
 
 - Matching.Text
     - The `Patterns` property has been removed.  Patterns should be retrieved by calling the `LearnPatterns()`
       method on the session object instead.
 
-## New Features
+### New Features
 
 - Changes that only affect those building their own DSLs
     - The [Samples](https://github.com/microsoft/prose) contain a new DSL Authoring tutorial.
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Compound.Split
     - The system now attempts to learn an ingestion program that obeys standard CSV quoting first
@@ -418,15 +418,15 @@ title: Release Notes
 - Common Framework
     - The interface for implementing a subprogram translator has been enhanced.
 
-# Release 6.1.0 -- 2018/04/16
+## Release 6.1.0 -- 2018/04/16
 
-## New Features
+### New Features
 
 - Compound.Split
     - Can now extract the schema of a fixed width file from a free-form text file description of the schema and use that
       to learn an extraction program.
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Compound.Split
     - Fixed width inference (for cases where the schema file is not available) is improved to prevent splitting inside
@@ -455,9 +455,9 @@ title: Release Notes
     - There is a new subprogram translator extension point interface which enables pattern based code generators to be
       plugged into the overall translation system.
 
-# Release 6.0.0 -- 2018/03/19
+## Release 6.0.0 -- 2018/03/19
 
-## Breaking Changes
+### Breaking Changes
 
 - Our session base class no longer implements `IDisposable`, and its serialization format has changed because the 
   `AllowBackgroundComputations` member has been deleted.
@@ -477,13 +477,13 @@ title: Release Notes
 - Transformation.Text's `GetSignificantInputClustersAsync` method has been removed and replaced with
   `GetSignificantInputsAsync`.
 
-## New Features
+### New Features
 
 - Compound.Split
     - Now supports Multi-record splitting which enables splitting of files with key-value pairs and pivoting the results
       into a table with the keys as columns.
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - The `LearnTopK` method on `Session` has a new optional parameter for requesting not only the top K programs but also a
   random sample of additional programs learned.
@@ -523,9 +523,9 @@ title: Release Notes
 - Transformation.Text
     - Fixed a bug in datetime rounding learning where sometimes too many dates were rounded.
 
-# Release 5.1.0 -- 2018/02/07
+## Release 5.1.0 -- 2018/02/07
 
-## Breaking Changes
+### Breaking Changes
 
 - The packaging of PROSE functionality has been significantly refactored both to reduce the number of DLLs and
   dependencies and to allow fine-grained selection of the functionality to be included in a consuming application.
@@ -562,7 +562,7 @@ title: Release Notes
       inefficient cast operations.
     - AutoComplete now uses IRow instead of IEnumerable<string> for input.
 
-## New Features
+### New Features
 
 - Extraction.Web is a new DSL for extracting structured data from HTML pages.
     - Can extract fields, sequences or tables given examples of specific web regions or text strings.
@@ -579,7 +579,7 @@ title: Release Notes
     - Split.Text
     - Extraction.Json
 
-## Bug Fixes / Enhancements
+### Bug Fixes / Enhancements
 
 - Compound.Split:
     - Considers more lines when determining the column delimiter.
@@ -624,9 +624,9 @@ title: Release Notes
 
 - Many other general performance and stability fixes.
 
-# Release 4.0.0 -- 2017/09/15
+## Release 4.0.0 -- 2017/09/15
 
-## Breaking Changes
+### Breaking Changes
 
 - State.Create method has been split into two versions: CreateForLearning and CreateForExecution.  The CreateForLearning
   version can be slower but is necessary (as you might imagine from the name) when the state is going to be used for
@@ -637,13 +637,13 @@ title: Release Notes
     - Plus the move to .netstandard 2.0 and corresponding upgrade to related corefx packages (mostly moving to version
       4.4.0)
 
-## New Features
+### New Features
 
 - A new API has been added for working with significant inputs which enables quick retrieval of some significant inputs
   and then async calculation and later retrieval of additional significant inputs as they become available.
 - Matching.Text now exposes the DescriptionTokens property to enable rich-text rendering of pattern descriptions.
 
-## Bug fixes / Enhancements
+### Bug fixes / Enhancements
 
 - Our nuget package should now work properly in both desktop .net and net core projects.
 - Compound.Split has a new constraint for specifying column delimiters.
@@ -653,9 +653,9 @@ title: Release Notes
   examples.
 - Miscellaneous perf and correctness fixes
 
-# Release 3.2.0 -- 2017/08/16
+## Release 3.2.0 -- 2017/08/16
 
-## New Features
+### New Features
 
 - A new Transformation.Tree DSL which may be used in scenarios such as code transformation/refactoring.
 - Transformation.Text improvements to date/time and number handling:
@@ -665,7 +665,7 @@ title: Release Notes
     - Lowercase am/pm in times
 - Matching.Text now has the ability to generate representative examples and a regex description for each cluster.
 
-## Bug fixes / Enhancements
+### Bug fixes / Enhancements
 
 - New Compound.Split streaming interface for running split programs on large files and the ability to specify a fill
   strategy for filling values in non-rectangular tables.
@@ -675,18 +675,18 @@ title: Release Notes
 - Extraction.Json no longer treats bare strings/numbers as valid json, so it won't learn a no-op program for them.
 - Miscellaneous correctness and performance improvements.
 
-# Release 3.1.3 -- 2017/07/18
+## Release 3.1.3 -- 2017/07/18
 
-## Bug fixes / Enhancements
+### Bug fixes / Enhancements
 
 - Transformation.Text date/time support has been fixed to prefer ranges over rounding in some key cases.
 - A number of general stability and performance improvements.
 
-# Release 3.0.0 -- 2017/06/28
+## Release 3.0.0 -- 2017/06/28
 
 *This release fixes the issues using the nuget packages in VS2015 and VS2017 (when using old-style packages.config).*
 
-## Breaking Changes
+### Breaking Changes
 
 - De-serializing programs in human readable format is removed.  Human readable was never a reliable serialization format
   (although it is nice for debugging purposes) because it does not contain enough information to guarantee backward
@@ -709,7 +709,7 @@ title: Release Notes
       arrays are flattened.  Default is for arrays to turn into rows, but there is a new constraint which allows
       flattening them into columns.
 
-## Bug fixes / Enhancements
+### Bug fixes / Enhancements
 
 - Detection.DataType is a new DLL added to the package which when given a series of strings can detect the datatypes
   those string values represent (ie. number, date, etc.).
@@ -727,12 +727,12 @@ title: Release Notes
 - Grammar files now support an annotation to indicate that a rule is deprecated (but kept in the grammar to allow
   deserialization of programs learned on older versions).
 
-# Release 2.3.0 -- 2017/05/15
+## Release 2.3.0 -- 2017/05/15
 
 *Note: We have had some reports of folks having trouble using the public nuget packages in VS2015 since the 2.0.0 release.
 We are aware of the issues and hope to have a fix soon.  In the meantime, the available packages should work in VS2017.*
 
-## Bug fixes / Enhancements
+### Bug fixes / Enhancements
 
 - This release includes significant performance improvements including:
     - A long-standing memory leak was fixed in the core framework that affected learning performance.
@@ -749,9 +749,9 @@ We are aware of the issues and hope to have a fix soon.  In the meantime, the av
 - Fix for a bug when generating programs for MergeColumns constraints with no separators/constants specified if there was
   a constant string at the end.
 
-# Release 2.2.0 -- 2017/04/24
+## Release 2.2.0 -- 2017/04/24
 
-## Bug fixes / Enhancements
+### Bug fixes / Enhancements
 
 - Transformation.Text now supports scientific notation and more flexible ways of indicating that a number is negative
   when parsing.  (It does not format numbers in these ways--only parses them.)
@@ -760,15 +760,15 @@ We are aware of the issues and hope to have a fix soon.  In the meantime, the av
 - Some API usability improvements have been made to Matching.Text.
 - Miscellaneous performance and stability improvements.
 
-# Release 2.1.0 -- 2017/04/17
+## Release 2.1.0 -- 2017/04/17
 
-## New Features
+### New Features
 
 - Split.Text now supports fixed width files.
 - Transformation.Json now includes Transformation.Text support.  This means it can synthesize programs which not only
   change the structure of a json document but also transform the values.
 
-## Bug fixes / Enhancements
+### Bug fixes / Enhancements
 
 - A number of bug fixes/enhancements were made to Extraction.Json--especially for the scenario of handling
   new-line delimited json (ndjson) documents or the similar case of having an input column containing a json
@@ -786,11 +786,11 @@ We are aware of the issues and hope to have a fix soon.  In the meantime, the av
   from a stream.  Instead, if a stream is passed to the session, it assumes that behavior automatically.
 - Split.File now supports new lines in quotes.
 
-# Release 2.0.1 -- 2017/03/17
+## Release 2.0.1 -- 2017/03/17
 
 Minor bug fix release.
 
-# Release 2.0.0 -- 2017/03/16
+## Release 2.0.0 -- 2017/03/16
 
 We have bumped the major number this time around because this release includes a breaking change (and we are doing our
 best to conform to semantic versioning).  The change is to the way `dslc` compiles grammar files.  Previously it produced
@@ -798,7 +798,7 @@ a .Net assembly.  Now it outputs c# source code which can be compiled into your 
 reduces the number of assemblies required to deploy your solution but also allows us to generate helper methods for 
 advanced scenarios involving manually creating program trees for a DSL.
 
-## New Features
+### New Features
 
 - Grammar files may now have a `using grammar <grammarName> = <class>.<property>` statement to indicate that the grammar
   depends on another grammar.
@@ -809,7 +809,7 @@ advanced scenarios involving manually creating program trees for a DSL.
   for the DSL.  If this is done, PROSE will call the `ILogger` with telemetry information such as the time required to
   learn programs, etc.
 
-## Bug fixes / Enhancements
+### Bug fixes / Enhancements
 
 - Significant inputs are now computed using the Z3 theorem prover from MSR (included in our nuget package as a set of 
   native libraries for Windows, Mac and Linux) which significantly decreases the time required to determine them.
@@ -822,13 +822,13 @@ advanced scenarios involving manually creating program trees for a DSL.
 - Several other ranking and stability improvements.
 
 
-# Release 1.1.0 -- 2017/02/15
+## Release 1.1.0 -- 2017/02/15
 
 With this release we are starting a regular monthly public release rhythm.  The biggest change in this month's release is 
 major improvements to our samples and documentation.  At the same time we have added several small new features and bug
 fixes.
 
-## New Features
+### New Features
 
 - Made more spec methods `protected internal` to enable third-party implementation of
   [`Spec`](https://prose-docs.azurewebsites.net/html/T_Microsoft_ProgramSynthesis_Specifications_Spec.htm) subclasses.
@@ -837,7 +837,7 @@ fixes.
 - More flexibility in time ranges in `Transformation.Text`.
 - Allowed omitting leading zeros at the start of numeric date formats in `Transformation.Text`.
 
-## Bug Fixes
+### Bug Fixes
 
 - Improved `RunMerge`'s handling of empty lines in `Split.File`.
 - Fixed learning with missing lookahead/lookbehind regexes in `Extraction.Text`
@@ -848,10 +848,10 @@ fixes.
   program across the SDK.
 
 
-# Release 1.0.3 -- 2017/01/22
+## Release 1.0.3 -- 2017/01/22
 
 First public release. Added support for .NET Core as well as several new DSLs.
 
-# Release 0.1.1 -- 2015/10/29
+## Release 0.1.1 -- 2015/10/29
 
 First public preview.

--- a/resources.md
+++ b/resources.md
@@ -3,10 +3,10 @@ title: Resources
 ---
 {::options auto_ids="false" /}
 
-# Publications
+## Publications
 {: .title}
 
-## Framework
+### Framework
 <ul>
 {% include paper.liquid.md title="FlashMeta: A Framework for Inductive Program Synthesis"
                     authors="Oleksandr Polozov, Sumit Gulwani"
@@ -16,7 +16,7 @@ title: Resources
 %}
 </ul>
 
-## Applications
+### Applications
 <ul>
 {% include paper.liquid.md title="Automating String Processing in Spreadsheets using Input-Output Examples"
                     authors="Sumit Gulwani"
@@ -53,7 +53,7 @@ title: Resources
 %}
 </ul>
 
-## Predictive Program Synthesis
+### Predictive Program Synthesis
 <ul>
 {% include paper.liquid.md title="Automated Data Extraction using Predictive Program Synthesis"
                     authors="Mohammad Raza, Sumit Gulwani"
@@ -62,7 +62,7 @@ title: Resources
 %}
 </ul>
 
-## Ranking
+### Ranking
 <ul>
 {% include paper.liquid.md title="Learning to Learn Programs from Examples: Going Beyond Program Structure"
                     authors="Kevin Ellis, Sumit Gulwani" 
@@ -72,7 +72,7 @@ title: Resources
 </ul>
 
 
-## User Interaction Models
+### User Interaction Models
 <ul>
 {% include paper.liquid.md title="User Interaction Models for Disambiguation in Programming by Example"
                     authors="Mikaël Mayer, Gustavo Soares, Maxim Grechkin, Vu Le, Mark Marron, Oleksandr Polozov, Rishabh Singh, Ben Zorn, Sumit Gulwani"
@@ -82,7 +82,7 @@ title: Resources
 </ul>
 
 
-# Talks
+## Talks
 {: .title}
 
 <ul>


### PR DESCRIPTION
- Modify the configuration to generate TOC entries from level 2 headings, instead of level 1.
- Bump one level of all headings on the page, such that no page has an explicit level 1 heading (this is reserved for the page title), but that the existing hierarchy is preserved.
- Add TOC to some pages.