### PR TITLE
Fixes labelled by bug in documentation website

### DIFF
--- a/_includes/menu.liquid.html
+++ b/_includes/menu.liquid.html
@@ -35,7 +35,7 @@
             {% unless page.url contains "/documentation/prose/tutorial" %}{% include menu-active.liquid.html url="/documentation/prose" %}{% endunless %}
         {% endcapture %}
         <li class="pure-menu-item pure-menu-has-children {{ prose_selected }}">
-            <a href="#" class="pure-menu-link" aria-haspopup="true">PROSE Framework</a>
+            <a href="#" id="proseFramework" class="pure-menu-link" aria-haspopup="true">PROSE Framework</a>
             <ul class="pure-menu-children">
                 {% include menu-item.liquid.html url="/documentation/prose/syntax" %}
                 {% include menu-item.liquid.html url="/documentation/prose/backpropagation" %}
@@ -46,23 +46,15 @@
         </li>
 
         <li class="pure-menu-item pure-menu-has-children {% include menu-active.liquid.html url="/documentation/extraction-text" %}">
-            <a href="#" class="pure-menu-link" aria-haspopup="true">Text Extraction</a>
+            <a href="#" id="textExtraction" class="pure-menu-link" aria-haspopup="true">Text Extraction</a>
             <ul class="pure-menu-children">
                 {% include menu-item.liquid.html url="/documentation/extraction-text/intro" title="Introduction" %}
                 {% include menu-item.liquid.html url="/documentation/extraction-text/usage" title="Usage" %}
             </ul>
         </li>
 
-        <li class="pure-menu-item pure-menu-has-children {% include menu-active.liquid.html url="/documentation/extraction-json" %}">
-            <a href="#" class="pure-menu-link" aria-haspopup="true">Json Extraction</a>
-            <ul class="pure-menu-children">
-                {% include menu-item.liquid.html url="/documentation/extraction-json/intro" title="Introduction" %}
-                {% include menu-item.liquid.html url="/documentation/extraction-json/usage" title="Usage" %}
-            </ul>
-        </li>
-
         <li class="pure-menu-item pure-menu-has-children {% include menu-active.liquid.html url="/documentation/split-text" %}">
-            <a href="#" class="pure-menu-link" aria-haspopup="true">Text Splitting</a>
+            <a href="#" id="textSplitting" class="pure-menu-link" aria-haspopup="true">Text Splitting</a>
             <ul class="pure-menu-children">
                 {% include menu-item.liquid.html url="/documentation/split-text/intro" title="Introduction" %}
                 {% include menu-item.liquid.html url="/documentation/split-text/usage" title="Usage" %}
@@ -70,7 +62,7 @@
         </li>
 
         <li class="pure-menu-item pure-menu-has-children {% include menu-active.liquid.html url="/documentation/transformation-text" %}">
-            <a href="#" class="pure-menu-link" aria-haspopup="true">Text Transformation</a>
+            <a href="#" id="textTransformation" class="pure-menu-link" aria-haspopup="true">Text Transformation</a>
             <ul class="pure-menu-children">
                 {% include menu-item.liquid.html url="/documentation/transformation-text/intro" title="Introduction" %}
                 {% include menu-item.liquid.html url="/documentation/transformation-text/usage" title="Usage" %}
@@ -78,15 +70,23 @@
         </li>
 
         <li class="pure-menu-item pure-menu-has-children {% include menu-active.liquid.html url="/documentation/matching-text" %}">
-            <a href="#" class="pure-menu-link" aria-haspopup="true">Matching Text</a>
+            <a href="#" id="matchingText" class="pure-menu-link" aria-haspopup="true">Matching Text</a>
             <ul class="pure-menu-children">
                 {% include menu-item.liquid.html url="/documentation/matching-text/intro" title="Introduction" %}
                 {% include menu-item.liquid.html url="/documentation/matching-text/usage" title="Usage" %}
             </ul>
         </li>
 
+        <li class="pure-menu-item pure-menu-has-children {% include menu-active.liquid.html url="/documentation/extraction-json" %}">
+            <a href="#" id="jsonExtraction" class="pure-menu-link" aria-haspopup="true">Json Extraction</a>
+            <ul class="pure-menu-children">
+                {% include menu-item.liquid.html url="/documentation/extraction-json/intro" title="Introduction" %}
+                {% include menu-item.liquid.html url="/documentation/extraction-json/usage" title="Usage" %}
+            </ul>
+        </li>
+
         <li class="pure-menu-item pure-menu-has-children {% include menu-active.liquid.html url="/documentation/transformation-json" %}">
-            <a href="#" class="pure-menu-link" aria-haspopup="true">Json Transformation</a>
+            <a href="#" id="jsonTransformation" class="pure-menu-link" aria-haspopup="true">Json Transformation</a>
             <ul class="pure-menu-children">
                 {% include menu-item.liquid.html url="/documentation/transformation-json/intro" title="Introduction" %}
                 {% include menu-item.liquid.html url="/documentation/transformation-json/usage" title="Usage" %}


### PR DESCRIPTION
The menu library would set labelledby to null because the menu label didn't have an id property. Adding an id for the menu links fixed the issue.