### PR TITLE
Address accessibility issues with navigation menu.

### DIFF
--- a/_includes/menu-item.liquid.html
+++ b/_includes/menu-item.liquid.html
@@ -3,7 +3,7 @@
 {% capture class_selected %}{% include menu-selected.liquid.html url=include.url %}{% endcapture %}
 {% capture url %}{% if include.absolute %}{{ include.url }}{% else %}{{ site.baseurl }}{{ include.url }}{% endif %}{% endcapture %}
 
-<li class="pure-menu-item {{ class_disabled }} {{ class_divided }} {{ class_selected }}" role="presentation">
+<li class="pure-menu-item {{ class_disabled }} {{ class_divided }} {{ class_selected }}">
     {% if include.disabled %}
         {{ include.title }}
     {% else %}

--- a/_includes/menu-item.liquid.html
+++ b/_includes/menu-item.liquid.html
@@ -8,10 +8,10 @@
         {{ include.title }}
     {% else %}
         {% if include.title %}
-    <a class="pure-menu-link" href="{{ url }}/" role="menuitem">{{ include.title }}</a>
+    <a class="pure-menu-link" href="{{ url }}/">{{ include.title }}</a>
         {% else %}
             {% assign current_page = site.pages | where_exp: "item", "item.url contains include.url" | first %}
-    <a class="pure-menu-link" href="{{ url }}/" role="menuitem">{{ current_page.title }}</a>
+    <a class="pure-menu-link" href="{{ url }}/">{{ current_page.title }}</a>
         {% endif %}
     {% endif %}
 </li>

--- a/_includes/menu.liquid.html
+++ b/_includes/menu.liquid.html
@@ -9,21 +9,21 @@
     {% include menu-item.liquid.html url="/faq" %}
 </ul>
 
-<ul class="pure-menu-list" aria-labelledby="demos">
-    <li id="demos" class="pure-menu-heading">Demos</li>
+<h2 id="demos" class="pure-menu-heading">Demos</h2>
+<ul class="pure-menu-list" aria-labelledby="demos">    
     {% include menu-item.liquid.html absolute=true url="https://prose-splittext.azurewebsites.net" title="Text Splitting" %}
 </ul>
 
-<ul class="pure-menu-list" aria-labelledby="videos">
-    <li id="videos" class="pure-menu-heading">Videos</li>
+<h2 id="videos" class="pure-menu-heading">Videos</h2>
+<ul class="pure-menu-list" aria-labelledby="videos">    
     {% include menu-item.liquid.html absolute=true url="https://databricks.com/session/programming-by-examples" title="Overview" %}
     {% include menu-item.liquid.html url="/demo/prose-showcase" title="PROSE Showcase" %}
     {% include menu-item.liquid.html absolute=true url="https://www.youtube.com/watch?v=w-k9WjRJvIY" title="Flash Fill/Extract" %}
     {% include menu-item.liquid.html absolute=true url="https://www.youtube.com/watch?v=XWRsxy8SbzY" title="Data Wrangling" %}
 </ul>
 
-<ul class="pure-menu-list" aria-labelledby="proseFramework">
-    <li id="proseFramework" class="pure-menu-heading">Prose Framework</li>
+<h2 id="proseFramework" class="pure-menu-heading">Prose Framework</h2>
+<ul class="pure-menu-list" aria-labelledby="proseFramework">    
     {% include menu-item.liquid.html url="/documentation/prose/syntax" %}
     {% include menu-item.liquid.html url="/documentation/prose/backpropagation" %}
     {% include menu-item.liquid.html url="/documentation/prose/concepts" %}
@@ -31,38 +31,38 @@
     {% include menu-item.liquid.html url="/documentation/prose/interactivity" %}
 </ul>
 
-<ul class="pure-menu-list" aria-labelledby="textExtraction">
-    <li id="textExtraction" class="pure-menu-heading">Text Extraction</li>
+<h2 id="textExtraction" class="pure-menu-heading">Text Extraction</h2>
+<ul class="pure-menu-list" aria-labelledby="textExtraction">    
     {% include menu-item.liquid.html url="/documentation/extraction-text/intro" title="Introduction" %}
     {% include menu-item.liquid.html url="/documentation/extraction-text/usage" title="Usage" %}
 </ul>
 
-<ul class="pure-menu-list" aria-labelledby="textSplitting">
-    <li id="textSplitting" class="pure-menu-heading">Text Splitting</li>
+<h2 id="textSplitting" class="pure-menu-heading">Text Splitting</h2>
+<ul class="pure-menu-list" aria-labelledby="textSplitting">    
     {% include menu-item.liquid.html url="/documentation/split-text/intro" title="Introduction" %}
     {% include menu-item.liquid.html url="/documentation/split-text/usage" title="Usage" %}
 </ul>
 
-<ul class="pure-menu-list" aria-labelledby="textTransformation">
-    <li id="textTransformation" class="pure-menu-heading">Text Transformation</li>
+<h2 id="textTransformation" class="pure-menu-heading">Text Transformation</h2>
+<ul class="pure-menu-list" aria-labelledby="textTransformation">    
     {% include menu-item.liquid.html url="/documentation/transformation-text/intro" title="Introduction" %}
     {% include menu-item.liquid.html url="/documentation/transformation-text/usage" title="Usage" %}
 </ul>
 
+<h2 id="matchingText" class="pure-menu-heading">Matching Text</h2>
 <ul class="pure-menu-list" aria-labelledby="matchingText">
-    <li id="matchingText" class="pure-menu-heading">Matching Text</li>
     {% include menu-item.liquid.html url="/documentation/matching-text/intro" title="Introduction" %}
     {% include menu-item.liquid.html url="/documentation/matching-text/usage" title="Usage" %}
 </ul>
 
-<ul class="pure-menu-list" aria-labelledby="jsonExtraction">
-    <li id="jsonExtraction" class="pure-menu-heading">Json Extraction</li>
+<h2 id="jsonExtraction" class="pure-menu-heading">Json Extraction</h2>
+<ul class="pure-menu-list" aria-labelledby="jsonExtraction">    
     {% include menu-item.liquid.html url="/documentation/extraction-json/intro" title="Introduction" %}
     {% include menu-item.liquid.html url="/documentation/extraction-json/usage" title="Usage" %}
 </ul>
 
-<ul class="pure-menu-list" aria-labelledby="jsonTransformation">
-    <li id="jsonTransformation" class="pure-menu-heading">Json Transformation</li>
+<h2 id="jsonTransformation" class="pure-menu-heading">Json Transformation</h2>
+<ul class="pure-menu-list" aria-labelledby="jsonTransformation">    
     {% include menu-item.liquid.html url="/documentation/transformation-json/intro" title="Introduction" %}
     {% include menu-item.liquid.html url="/documentation/transformation-json/usage" title="Usage" %}
 </ul>

--- a/_layouts/default.liquid.html
+++ b/_layouts/default.liquid.html
@@ -15,11 +15,11 @@
         <span></span>
     </a>
 
-    <div role="navigation" id="menu">
+    <nav id="menu">
         <div class="pure-menu">
             {% include menu.liquid.html %}
         </div>
-    </div>
+    </nav>
 
     <div role="main" id="main">
         {% unless page.path == "index.liquid.html" %}


### PR DESCRIPTION
The use of `role=presentation` triggers an accessibility issue with axe. `role=menuitem` can only be used with `menu` role, not `navigation` role. Change menu headers to use `h2`; otherwise screen readers incorrectly count the number of items in the list (off-by-one).